### PR TITLE
Fixing how pathinfo array is called.

### DIFF
--- a/code/TrailingSlashExt.php
+++ b/code/TrailingSlashExt.php
@@ -17,9 +17,10 @@ class TrailingSlashExt extends Extension {
 
 		if ($request && $request->isGET()) {
 			$url = $request->getVar('url');
+			$urlPathInfo = pathinfo($url);
 
-			/* ignore Ajax requests and URLs that contain a an extension */
-			if (Director::is_ajax() || isset(pathinfo($url)['extension'])) {
+			/* ignore Ajax requests and URLs that contain an extension */
+			if (Director::is_ajax() || isset($urlPathInfo['extension'])) {
 				return false;
 			}
 


### PR DESCRIPTION
Some servers can't handle calling `pathinfo($url)['extension']`. 

I have fixed this up by first assigning the results of `pathinfo($url)` to a variable and then checking if `$urlPathInfo['extension']` is set.
