### PR TITLE
BUGFIX 'silverstripe/staticpublishqueue' user agent should be ignored

### DIFF
--- a/src/Middleware/TrailingSlashRedirector.php
+++ b/src/Middleware/TrailingSlashRedirector.php
@@ -68,6 +68,7 @@ class TrailingSlashRedirector implements HTTPMiddleware
             $params = $request->getVars();
 
             if (!Director::is_ajax()
+                && $request->getHeader('User-Agent') != 'silverstripe/staticpublishqueue'
                 && !isset($urlPathInfo['extension'])
                 && empty($params)
                 && !preg_match(


### PR DESCRIPTION
When using the `silverstripe/silverstripe-staticpublishqueue` module the `REQUEST_URI` is updated so what's used for the request will be different from what is defined in `$_SERVER['REQUEST_URI']`.

As the `REQUEST_URI` can no longer be relied on then it makes more sense to ignore the user agent for staticpublishqueue.

ref; https://github.com/silverstripe/silverstripe-staticpublishqueue/blob/master/src/Publisher.php#L82-L101