### PR TITLE
Fixes some setups of unwrapped % in yml breaking site

### DIFF
--- a/_config/middleware.yml
+++ b/_config/middleware.yml
@@ -9,4 +9,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        CustomMiddleware: %$TrailingSlashRedirector
+        CustomMiddleware: '%$TrailingSlashRedirector'


### PR DESCRIPTION
On some setups there is the following error:

    Fatal error: Uncaught Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 7 (near "CustomMiddleware: %$TrailingSlashRedirector").

Wrapping the string with single quotes fixes this issue.