### PR TITLE
Allow SS 6.0 via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "issues": "https://github.com/axllent/silverstripe-trailing-slash/issues"
     },
     "require": {
-        "silverstripe/framework": "^4.0 || ^5.0"
+        "silverstripe/framework": "^4.0 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Setting composer.json to allow SS6.0.  Looked through all code to ensure there were no issues with the API changes.